### PR TITLE
Add live S3/API prune functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
          }
       },
       "@elastic/elasticsearch": {
-         "version": "7.8.0",
-         "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.8.0.tgz",
-         "integrity": "sha512-rUOTNN1At0KoN0Fcjd6+J7efghuURnoMTB/od9EMK6Mcdebi6N3z5ulShTsKRn6OanS9Eq3l/OmheQY1Y+WLcg==",
+         "version": "7.9.0",
+         "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.9.0.tgz",
+         "integrity": "sha512-iSLQvQafspN03YayzccShkKgJeRsUbncbtIhIL2SeiH01xwdnOZcp0nCvSNaMsH28A3YQ4ogTs9K8eXe42UaUA==",
          "requires": {
             "debug": "^4.1.1",
             "decompress-response": "^4.2.0",
@@ -72,18 +72,18 @@
          }
       },
       "@types/cors": {
-         "version": "2.8.6",
-         "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.6.tgz",
-         "integrity": "sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==",
+         "version": "2.8.7",
+         "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.7.tgz",
+         "integrity": "sha512-sOdDRU3oRS7LBNTIqwDkPJyq0lpHYcbMTt0TrjzsXbk/e37hcLTH6eZX7CdbDeN0yJJvzw9hFBZkbtCSbk/jAQ==",
          "dev": true,
          "requires": {
             "@types/express": "*"
          }
       },
       "@types/express": {
-         "version": "4.17.6",
-         "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-         "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+         "version": "4.17.7",
+         "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
+         "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
          "dev": true,
          "requires": {
             "@types/body-parser": "*",
@@ -102,9 +102,9 @@
          }
       },
       "@types/express-serve-static-core": {
-         "version": "4.17.7",
-         "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-         "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+         "version": "4.17.9",
+         "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
+         "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
          "dev": true,
          "requires": {
             "@types/node": "*",
@@ -113,22 +113,20 @@
          }
       },
       "@types/mime": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-         "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+         "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
          "dev": true
       },
       "@types/node": {
-         "version": "14.0.13",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-         "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
-         "dev": true
+         "version": "14.6.0",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+         "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
       },
       "@types/pino": {
          "version": "6.3.0",
          "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.0.tgz",
          "integrity": "sha512-AuZ32IbQlzW3XY9jA9X8iXkhMTtloKWHz1Ze23ClPx7L8ES69BNGfH308LsU2tHnDCLLCFoZvMn8+1njBx2EKg==",
-         "dev": true,
          "requires": {
             "@types/node": "*",
             "@types/pino-std-serializers": "*",
@@ -136,10 +134,9 @@
          }
       },
       "@types/pino-http": {
-         "version": "5.0.1",
-         "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.0.1.tgz",
-         "integrity": "sha512-zjFPPOCJ347oXMORUblC18pWIN0gLaHjezuvghxuWCxVreECCnmt8Oj6jdGisc5R6czFIORNSjMOKVmYH6NGqw==",
-         "dev": true,
+         "version": "5.0.4",
+         "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.0.4.tgz",
+         "integrity": "sha512-i9Awlslw9Yhrm04SBTt/r89Ca2oQb38ewzoFRgZ0oFUYBVYCgzUCRRksNZGP7Q2nYoGBn+pAjhB1bzReGKs8xw==",
          "requires": {
             "@types/pino": "*"
          }
@@ -148,15 +145,14 @@
          "version": "2.4.1",
          "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
          "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
-         "dev": true,
          "requires": {
             "@types/node": "*"
          }
       },
       "@types/qs": {
-         "version": "6.9.3",
-         "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
-         "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
+         "version": "6.9.4",
+         "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
+         "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
          "dev": true
       },
       "@types/range-parser": {
@@ -166,9 +162,9 @@
          "dev": true
       },
       "@types/serve-static": {
-         "version": "1.13.4",
-         "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-         "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+         "version": "1.13.5",
+         "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
+         "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
          "dev": true,
          "requires": {
             "@types/express-serve-static-core": "*",
@@ -179,7 +175,6 @@
          "version": "0.7.0",
          "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
          "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-         "dev": true,
          "requires": {
             "@types/node": "*"
          }
@@ -294,9 +289,9 @@
          "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
       },
       "aws-sdk": {
-         "version": "2.698.0",
-         "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.698.0.tgz",
-         "integrity": "sha512-6S01wJMGwVLU7uld3sNXd1YuZab/Rha7qMFznxOHjkX/N+N0N1+Spd0T4NqXX9ebSai+OfeLT2H0IwyH4LAIZw==",
+         "version": "2.737.0",
+         "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.737.0.tgz",
+         "integrity": "sha512-GQ4pplsIyiuFUwlFINhrw5lE9PrY5NIr/EDU5Me9mNGTW5pJXLVpK1ASwlReVhKAZisMUHFHLNvLcGRssR+drg==",
          "requires": {
             "buffer": "4.9.2",
             "events": "1.1.1",
@@ -309,11 +304,6 @@
             "xml2js": "0.4.19"
          },
          "dependencies": {
-            "sax": {
-               "version": "1.2.1",
-               "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-               "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-            },
             "uuid": {
                "version": "3.3.2",
                "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -341,9 +331,9 @@
          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
       },
       "aws4": {
-         "version": "1.10.0",
-         "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-         "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+         "version": "1.10.1",
+         "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+         "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
       },
       "balanced-match": {
          "version": "1.0.0",
@@ -545,9 +535,9 @@
                }
             },
             "yargs": {
-               "version": "15.3.1",
-               "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-               "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+               "version": "15.4.1",
+               "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+               "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
                "requires": {
                   "cliui": "^6.0.0",
                   "decamelize": "^1.2.0",
@@ -559,7 +549,7 @@
                   "string-width": "^4.2.0",
                   "which-module": "^2.0.0",
                   "y18n": "^4.0.0",
-                  "yargs-parser": "^18.1.1"
+                  "yargs-parser": "^18.1.2"
                }
             }
          }
@@ -927,9 +917,9 @@
          }
       },
       "figlet": {
-         "version": "1.4.0",
-         "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.4.0.tgz",
-         "integrity": "sha512-CxxIjEKHlqGosgXaIA+sikGDdV6KZOOlzPJnYuPgQlOSHZP5h9WIghYI30fyXnwEVeSH7Hedy72gC6zJrFC+SQ=="
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz",
+         "integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww=="
       },
       "finalhandler": {
          "version": "1.1.2",
@@ -1044,12 +1034,25 @@
          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
       },
       "har-validator": {
-         "version": "5.1.3",
-         "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-         "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+         "version": "5.1.5",
+         "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+         "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
          "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
+         },
+         "dependencies": {
+            "ajv": {
+               "version": "6.12.4",
+               "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+               "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+               "requires": {
+                  "fast-deep-equal": "^3.1.1",
+                  "fast-json-stable-stringify": "^2.0.0",
+                  "json-schema-traverse": "^0.4.1",
+                  "uri-js": "^4.2.2"
+               }
+            }
          }
       },
       "harmony-reflect": {
@@ -1076,9 +1079,9 @@
          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
       },
       "highlight.js": {
-         "version": "9.18.1",
-         "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-         "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+         "version": "9.18.3",
+         "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+         "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ=="
       },
       "http-errors": {
          "version": "1.7.3",
@@ -1229,9 +1232,9 @@
          }
       },
       "lodash": {
-         "version": "4.17.19",
-         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-         "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+         "version": "4.17.20",
+         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+         "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
       },
       "make-error": {
          "version": "1.3.6",
@@ -1568,9 +1571,9 @@
          }
       },
       "pino-elasticsearch": {
-         "version": "5.2.0",
-         "resolved": "https://registry.npmjs.org/pino-elasticsearch/-/pino-elasticsearch-5.2.0.tgz",
-         "integrity": "sha512-n5JytVBghpEcQUF+V+jNdi6PSvcFwQda4cbl+OdAKKVYpuinRGbhy/vt3Jid9FjOTs/FlxTHejOCMWWt5mUcag==",
+         "version": "5.3.0",
+         "resolved": "https://registry.npmjs.org/pino-elasticsearch/-/pino-elasticsearch-5.3.0.tgz",
+         "integrity": "sha512-jzU7dQ5W2DYGpVUHuyJkRcKnOsKucGrDSPJKl6Jz11SIPusroDV5JrCZ95QrLQ1bVA0bLdg4G4hBtijtGAB7nQ==",
          "requires": {
             "@elastic/elasticsearch": "^7.7.1",
             "fast-json-parse": "^1.0.3",
@@ -1611,16 +1614,16 @@
          },
          "dependencies": {
             "pino": {
-               "version": "6.4.0",
-               "resolved": "https://registry.npmjs.org/pino/-/pino-6.4.0.tgz",
-               "integrity": "sha512-TRDp5fJKRBtVlxd4CTox3rJL+TzwQztB/VNmT5n87zFgKVU7ztnmZkcX1zypPP+3ZZcveOTYKJy74UXdVBaXFQ==",
+               "version": "6.5.1",
+               "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.1.tgz",
+               "integrity": "sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==",
                "requires": {
                   "fast-redact": "^2.0.0",
                   "fast-safe-stringify": "^2.0.7",
                   "flatstr": "^1.0.12",
                   "pino-std-serializers": "^2.4.2",
                   "quick-format-unescaped": "^4.0.1",
-                  "sonic-boom": "^1.0.0"
+                  "sonic-boom": "^1.0.2"
                }
             },
             "quick-format-unescaped": {
@@ -1629,9 +1632,9 @@
                "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
             },
             "sonic-boom": {
-               "version": "1.0.2",
-               "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.2.tgz",
-               "integrity": "sha512-sRMmXu7uFDXoniGvtLHuQk5KWovLWoi6WKASn7rw0ro41mPf0fOolkGp4NE6680CbxvNh26zWNyFQYYWXe33EA==",
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+               "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
                "requires": {
                   "atomic-sleep": "^1.0.0",
                   "flatstr": "^1.0.12"
@@ -1807,22 +1810,22 @@
          }
       },
       "request-promise": {
-         "version": "4.2.5",
-         "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
-         "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+         "version": "4.2.6",
+         "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+         "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
          "requires": {
             "bluebird": "^3.5.0",
-            "request-promise-core": "1.1.3",
+            "request-promise-core": "1.1.4",
             "stealthy-require": "^1.1.1",
             "tough-cookie": "^2.3.3"
          }
       },
       "request-promise-core": {
-         "version": "1.1.3",
-         "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-         "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+         "version": "1.1.4",
+         "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+         "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
          "requires": {
-            "lodash": "^4.17.15"
+            "lodash": "^4.17.19"
          }
       },
       "require-directory": {
@@ -1854,9 +1857,9 @@
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
       },
       "sax": {
-         "version": "1.2.4",
-         "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-         "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+         "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
       },
       "secure-json-parse": {
          "version": "2.1.0",
@@ -1969,9 +1972,9 @@
          }
       },
       "split2": {
-         "version": "3.1.1",
-         "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-         "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+         "version": "3.2.1",
+         "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.1.tgz",
+         "integrity": "sha512-wmX3JdfKWWghQSjezpJyMxlFodG/vNbV/Y9scsCqYSDWo0nCdteOdzqh8z1NDxpcIZB6BhkqWo6642VI/HA3oA==",
          "requires": {
             "readable-stream": "^3.0.0"
          },
@@ -2029,9 +2032,9 @@
          "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
       },
       "string-similarity": {
-         "version": "4.0.1",
-         "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.1.tgz",
-         "integrity": "sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw=="
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.2.tgz",
+         "integrity": "sha512-eCsPPyoQBgY4TMpVD6DVfO7pLrimUONriaO4Xjp3WPUW0YnNLqdHgRj23xotLlqrL90eJhBeq3zdAJf2mQgfBQ=="
       },
       "string-width": {
          "version": "1.0.2",
@@ -2094,9 +2097,9 @@
          }
       },
       "thenify": {
-         "version": "3.3.0",
-         "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-         "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+         "version": "3.3.1",
+         "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+         "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
          "requires": {
             "any-promise": "^1.0.0"
          }
@@ -2149,34 +2152,29 @@
          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
       },
       "tuckbot-util": {
-         "version": "git+https://github.com/kyleratti/tuckbot-util.git#af6b0886cc269f15c5c6224c1ca0b13e79aef6db",
+         "version": "git+https://github.com/kyleratti/tuckbot-util.git#b1caec2ad2832f1e07fc7601d2ea94bd66a25665",
          "from": "git+https://github.com/kyleratti/tuckbot-util.git",
          "requires": {
             "@elastic/ecs-pino-format": "^0.1.0",
-            "dotenv": "^6.2.0",
-            "pino": "^6.3.2",
-            "pino-elasticsearch": "^5.1.0",
-            "pino-multi-stream": "^5.0.0",
-            "rimraf": "^3.0.1",
-            "snoowrap": "^1.20.1"
+            "dotenv": "^8.2.0",
+            "pino": "^6.4.0",
+            "pino-elasticsearch": "^5.2.0",
+            "pino-multi-stream": "^5.1.1",
+            "rimraf": "^3.0.2",
+            "snoowrap": "^1.21.0"
          },
          "dependencies": {
-            "dotenv": {
-               "version": "6.2.0",
-               "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-               "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
-            },
             "pino": {
-               "version": "6.4.0",
-               "resolved": "https://registry.npmjs.org/pino/-/pino-6.4.0.tgz",
-               "integrity": "sha512-TRDp5fJKRBtVlxd4CTox3rJL+TzwQztB/VNmT5n87zFgKVU7ztnmZkcX1zypPP+3ZZcveOTYKJy74UXdVBaXFQ==",
+               "version": "6.5.1",
+               "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.1.tgz",
+               "integrity": "sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==",
                "requires": {
                   "fast-redact": "^2.0.0",
                   "fast-safe-stringify": "^2.0.7",
                   "flatstr": "^1.0.12",
                   "pino-std-serializers": "^2.4.2",
                   "quick-format-unescaped": "^4.0.1",
-                  "sonic-boom": "^1.0.0"
+                  "sonic-boom": "^1.0.2"
                }
             },
             "quick-format-unescaped": {
@@ -2185,9 +2183,9 @@
                "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
             },
             "sonic-boom": {
-               "version": "1.0.2",
-               "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.2.tgz",
-               "integrity": "sha512-sRMmXu7uFDXoniGvtLHuQk5KWovLWoi6WKASn7rw0ro41mPf0fOolkGp4NE6680CbxvNh26zWNyFQYYWXe33EA==",
+               "version": "1.1.0",
+               "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+               "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
                "requires": {
                   "atomic-sleep": "^1.0.0",
                   "flatstr": "^1.0.12"
@@ -2274,9 +2272,9 @@
          }
       },
       "typescript": {
-         "version": "3.9.5",
-         "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-         "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+         "version": "3.9.7",
+         "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+         "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
          "dev": true
       },
       "ultron": {

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
     "express-pino-logger": "^4.0.0",
     "http-status-codes": "^1.4.0",
     "snoowrap": "^1.21.0",
-    "sqlite3": "^4.1.1",
+    "sqlite3": "^4.2.0",
     "tuckbot-util": "git+https://github.com/kyleratti/tuckbot-util.git",
     "typeorm": "^0.2.25"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.6",
-    "@types/express": "^4.17.6",
+    "@types/cors": "^2.8.7",
+    "@types/express": "^4.17.7",
     "@types/express-pino-logger": "^4.0.2",
-    "@types/node": "^14.0.13",
+    "@types/node": "^14.6.0",
     "rimraf": "^3.0.2",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.5"
+    "typescript": "^3.9.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "types": "dts/index.d.ts",
   "scripts": {
     "clean": "rimraf lib/*",
+    "prebuild": "npm run clean",
     "build": "tsc -p src",
+    "prewatch": "npm run clean",
     "watch": "tsc -p src -w",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
This fixes the output overflow issue when logging S3/API pruning and enables authenticate API calls to prune videos from the database and S3 if they are missing from either location. Each pruned video will also attempt to remove from a-centralized-mirror, too.